### PR TITLE
Add support for extensions.

### DIFF
--- a/schema/response.py
+++ b/schema/response.py
@@ -75,6 +75,13 @@ class Response():
 
 def create_error_response(errors=None, message=None):
     """Create an error response.
+
+    Args:
+        errors (dict): List of errors (if any.)
+        message: Message that will be provided as part of the response
+            (optional.)
+    Return:
+        `Response`: The error response.
     """
 
     return Response(
@@ -85,6 +92,11 @@ def create_error_response(errors=None, message=None):
 
 def create_success_response(message=None):
     """Create a success response.
+
+    Args:
+        message: The response from the schema (optional.)
+    Return:
+        `Response`: a successful response.
     """
 
     return Response(

--- a/schema/utils.py
+++ b/schema/utils.py
@@ -34,3 +34,32 @@ def key_exclude(dictionary, keys):
     """
 
     return {key: val for key, val in dictionary.items() if key not in keys}
+
+
+def dict_from_strings(array, separator='.'):
+    """Recreate a dictionary from strings that are in an array.
+
+    If you have strings such as "user.id", "user.name", those ideally can be
+    turned into a dictionary where user is the principal key and name, id two
+    values of this dictionary.
+
+    Args:
+        array (array): The array to turn into a dict.
+    Return:
+        dict: The dictionary.
+    """
+
+    dictionary = {}
+
+    for string in array:
+        parts = string.split(separator)
+        key = parts[0]
+        last_parts = separator.join(parts[1:])
+
+        if last_parts:
+            dictionary.setdefault(key, {}).update(
+                dict_from_strings([last_parts], separator=separator))
+        else:
+            dictionary.update({key: None})
+
+    return dictionary

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -290,3 +290,18 @@ def test_create_table_without_fields(table_name):
 
     with pytest.raises(Exception):
         tb.table.create_table()
+
+
+def test_extension_usage(user_schema):
+    @user_schema.extension('stats')
+    def stats(item, fields):
+        return {'days': 10, 'fields': fields}
+
+    response = user_schema.create(id='testextension', username='michael')
+    assert response.success
+
+    response = user_schema.fetch_one(
+        username=Equal('michael'), fields=['stats.foobar', 'stats.tests.bar'])
+    assert response.stats.get('days') == 10
+    assert 'foobar' in response.stats.get('fields')
+    assert 'bar' in response.stats.get('fields').get('tests')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -108,3 +108,11 @@ def test_ensure_index(monkeypatch, full_schema):
     assert not resp.success
     assert 'id' in resp.errors
     assert 'username' in resp.errors
+
+
+def test_extensions(full_schema):
+    @full_schema.extension('stats')
+    def stats(item, fields):
+        return
+
+    assert full_schema.extensions.get('stats')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,3 +5,11 @@ def test_key_dict():
     dictionary = {'key1': 'value1', 'key2': 'value2'}
     resp = utils.key_dict(dictionary, True)
     assert resp.get('key1') is True
+
+
+def test_dict_from_strings():
+    array = ['user.stats.daily', 'user.username']
+    response = utils.dict_from_strings(array)
+    assert len(response) == 1
+    assert len(response.get('user')) == 2
+    assert response.get('user').get('username') is None


### PR DESCRIPTION
Extensions are additional fields that can be fetched. For instance:

```
user = Schema(...)

@user.extension('stats')
def stats(item, fields):
    return dict()
```

If the user is fetched with the field `stats`, it will return the user object with
a `stats` key on it.

---
_Michael is the founder of CreativeList. Learn more about [Creativelist - The Creator Search Engine](http://www.creativelist.io). It's a [search engine](http://www.creativelist.io/about) specialized in finding [designers](http://www.creativelist.io/hire/designer), [photographers](http://www.creativelist.io/hire/photographer), or any [type of creatives](http://www.creativelist.io/hire/creatives) in big cities like [new york](http://www.creativelist.io/hire/creatives/new-york-city), [los angeles](http://www.creativelist.io/hire/creatives/los-angeles), [san francisco](http://www.creativelist.io/hire/creatives/san-francisco) or near you._