### PR TITLE
Update field handlers

### DIFF
--- a/schema/utils.py
+++ b/schema/utils.py
@@ -57,10 +57,9 @@ def dict_from_strings(array, separator='.'):
         last_parts = separator.join(parts[1:])
 
         if last_parts:
-            dictionary.setdefault(key, {}).update(
-                dict_from_strings([last_parts], separator=separator))
+            dictionary.setdefault(key, []).append(last_parts)
         else:
-            dictionary.update({key: None})
+            dictionary.update({key: []})
 
     return dictionary
 

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -92,7 +92,7 @@ def test_extension(user_schema):
     assert isinstance(new_schema, Schema)
     assert new_schema.table.name == user_schema.table.name
     assert len(new_schema.indexes) == len(user_schema.indexes)
-    assert len(new_schema.fields) -1 == len(user_schema.fields)
+    assert len(new_schema.fields) - 1 == len(user_schema.fields)
     assert not new_schema.table.schema == user_schema
 
 
@@ -278,7 +278,7 @@ def test_between_request(stats_schema):
         resp = stats_schema.create(user_id=300, day_id=day, metrics=metrics)
 
     resp = stats_schema.fetch(user_id=Equal(300), day_id=Between(30, 40))
-    assert len(resp.message) == 11 # 40 is included
+    assert len(resp.message) == 11  # 40 is included
 
 
 def test_dynamo_table_creation(table_name):
@@ -344,12 +344,12 @@ def test_extension_usage(user_schema):
         username=Equal('michael'), fields=['stats.foobar', 'stats.tests.bar'])
     assert response.stats.get('days') == 10
     assert 'foobar' in response.stats.get('fields')
-    assert 'bar' in response.stats.get('fields').get('tests')
+    assert 'tests.bar' in response.stats.get('fields')
 
     response = user_schema.fetch_one(
         username=Equal('michael'),
         fields=['history', 'stats.foobar', 'stats.tests.bar'])
     assert response.stats.get('days') == 10
     assert 'foobar' in response.stats.get('fields')
-    assert 'bar' in response.stats.get('fields').get('tests')
+    assert 'tests.bar' in response.stats.get('fields')
     assert response.history.get('length') == 20

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,4 +12,5 @@ def test_dict_from_strings():
     response = utils.dict_from_strings(array)
     assert len(response) == 1
     assert len(response.get('user')) == 2
-    assert response.get('user').get('username') is None
+    assert 'username' in response.get('user')
+    assert 'stats.daily' in response.get('user')


### PR DESCRIPTION
The previous version was spliting the fields on the "." and recreating
a dictionary. For instance:

```
['user.username', 'user.stats.monthly']
```

Was generating:

```
{'user': {
    'username': None,
    'stats': {
        'monthly': None
    }}
```

The issue: when you fetch a model, you pass an array: ['user.username', ...],
so if you need to fetch again on an extension, you should also pass the same
signature.

Now, the flow is a lot easier to understand:

```
 [user.username, user.stats.monthly]

 calls: user and pass the above, find the username and fetch the extension
        stats and pass to stats: ['stats.monthly']
```

---
_Michael is the founder of CreativeList. Learn more about [Creativelist - The Creator Search Engine](http://www.creativelist.io). It's a [search engine](http://www.creativelist.io/about) specialized in finding [designers](http://www.creativelist.io/hire/designer), [photographers](http://www.creativelist.io/hire/photographer), or any [type of creatives](http://www.creativelist.io/hire/creatives) in big cities like [new york](http://www.creativelist.io/hire/creatives/new-york-city), [los angeles](http://www.creativelist.io/hire/creatives/los-angeles), [san francisco](http://www.creativelist.io/hire/creatives/san-francisco) or near you._