### PR TITLE
Reverse Secondary Indexes.

### DIFF
--- a/sukimu/dynamodb.py
+++ b/sukimu/dynamodb.py
@@ -49,6 +49,12 @@ class TableDynamo(schema.Table):
             self.hash = index.hash
             self.range = index.range
 
+        keys = index.keys
+        self.indexes.setdefault(keys[0], []).append(index)
+
+        if len(keys) > 1:
+            self.indexes.setdefault('-'.join(keys), []).append(index)
+
     def create(self, data):
         """Create an item.
 
@@ -136,7 +142,7 @@ class TableDynamo(schema.Table):
         if index:
             if index.name:
                 data['index'] = index.name
-                
+
             data['reverse'] = sort is consts.SORT_DESCENDING
             dynamo = list(self.table.query_2(**data))
         else:

--- a/sukimu/schema.py
+++ b/sukimu/schema.py
@@ -420,16 +420,9 @@ class Table():
             self.add_index(index)
 
     def add_index(self, index):
-        keys = index.keys
-        keys.sort()
-        for key in keys:
-            self.indexes.setdefault(key, []).append(index)
-
-        if len(keys) > 1:
-            self.indexes.setdefault('-'.join(keys), []).append(index)
+        return NotImplemented
 
     def find_index(self, fields):
-        fields.sort()
         key = '-'.join(fields)
         if key in self.indexes:
             return self.indexes.get(key)[0]


### PR DESCRIPTION
Reverse secondary indexes (index: user_id, day_id, reverse would be day_id, user_id). This forces all the query keys to be ordered.