### PR TITLE
Errors be the first argument of the FieldException

### DIFF
--- a/sukimu/schema.py
+++ b/sukimu/schema.py
@@ -147,7 +147,7 @@ class Schema():
                 data[name] = field.validate(value)
 
             except exceptions.FieldException as e:
-                errors[name] = e
+                errors[name] = e.args[0]
                 status = False
 
         if errors:

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -97,9 +97,7 @@ def test_can_create_fixtures(user_schema, thread_schema):
 def test_create_an_entry_with_wrong_field(user_schema):
     resp = user_schema.create(id='30', username='michael', random_field='test')
     assert not resp
-    assert isinstance(
-        resp.errors.get('message').get('random_field'),
-        exceptions.FieldException)
+    assert isinstance(resp.errors.get('message').get('random_field'), str)
 
     resp = user_schema.fetch_one(id=Equal('30'))
     assert not resp


### PR DESCRIPTION
When errors are returned, the full exception is returned, instead
only the argument provided to the Exception should be provided.

In most cases: this will simply be the reason of why the validation
has failed.